### PR TITLE
[OTP-21] Remove get_stacktrace calls to be compatible with OTP21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
-  - 20.2
+  - 21.1
 script:
-  - rebar3 do dialyzer, ct
+  - rebar3 version
+  - rebar3 do dialyzer, ct --readable=false

--- a/rebar.config
+++ b/rebar.config
@@ -62,6 +62,8 @@
   ]}
 ]}.
 
+{erl_first_files, ["src/xdb_transform.erl"]}.
+
 %% == Cover ==
 
 {cover_enabled, true}.

--- a/src/adapters/xdb_mnesia_adapter.erl
+++ b/src/adapters/xdb_mnesia_adapter.erl
@@ -89,6 +89,7 @@ in_transaction(_Repo) ->
   mnesia:is_transaction().
 
 %% @hidden
+-spec rollback(atom(), any()) -> no_return().
 rollback(Repo, Value) ->
   case in_transaction(Repo) of
     true  -> error(Value);

--- a/src/test/xdb_ct.erl
+++ b/src/test/xdb_ct.erl
@@ -14,7 +14,7 @@
 %%% API
 %%%===================================================================
 
--spec assert_error(fun(), term()) -> any().
+-spec assert_error(fun(() -> no_return()), term()) -> any().
 assert_error(Fun, Error) ->
   try Fun()
   catch

--- a/src/test/xdb_repo_basic_test.erl
+++ b/src/test/xdb_repo_basic_test.erl
@@ -45,7 +45,12 @@
 init_per_testcase(_, Config) ->
   Repo = xdb_lib:keyfetch(repo, Config),
   {ok, _} = Repo:start_link(),
-  {_, _} = Repo:delete_all(person),
+  %% On the first run this table does not exist and this will throw an error
+  try
+    Repo:delete_all(person)
+  catch _:_ ->
+    ok
+  end,
   Config.
 
 -spec end_per_testcase(atom(), xdb_ct:config()) -> xdb_ct:config().
@@ -211,7 +216,7 @@ t_update(Config) ->
   ok = seed(Config),
   Person = Repo:get(person, 1),
 
-  {ok, CS} =
+  {ok, _CS} =
     xdb_ct:pipe(Person, [
       {fun person:changeset/2, [#{first_name => <<"Joe2">>}]},
       {fun Repo:update/1, []}

--- a/src/xdb_lib.erl
+++ b/src/xdb_lib.erl
@@ -144,19 +144,19 @@ reduce_while(Fun, AccIn, List) when is_function(Fun, 2) ->
   catch
     throw:{halt, AccOut} ->
       AccOut;
-    Kind:Reason ->
-      erlang:raise(Kind, Reason, erlang:get_stacktrace())
+    _:Reason ->
+      erlang:error(Reason)
   end.
 
 -spec raise(any()) -> no_return().
 raise(Reason) ->
-  erlang:raise(error, Reason, erlang:get_stacktrace()).
+  erlang:error(Reason).
 
 -spec raise(atom(), any()) -> no_return().
 raise(Error, Reason) when is_atom(Error) ->
-  erlang:raise(error, {Error, Reason}, erlang:get_stacktrace()).
+  erlang:error({Error, Reason}).
 
 -spec raise(atom(), string(), [any()]) -> no_return().
 raise(Error, Text, Args) when is_atom(Error) ->
   Reason = stringify(Text, Args),
-  erlang:raise(error, {Error, Reason}, erlang:get_stacktrace()).
+  erlang:error({Error, Reason}).

--- a/test/xdb_lib_SUITE.erl
+++ b/test/xdb_lib_SUITE.erl
@@ -1,5 +1,7 @@
 -module(xdb_lib_SUITE).
 
+-dialyzer({nowarn_function, t_raise/1}).
+
 %% Common Test
 -export([
   all/0


### PR DESCRIPTION
Hey Carlos, here's the change we discussed: https://github.com/cabol/cross_db/issues/9