### PR TITLE
Add parse transform module to `erl_first_files`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,6 +26,8 @@
   {iso8601, "1.2.3"}
 ]}.
 
+{erl_first_files, ["src/xdb_transform.erl"]}.
+
 %% == Profiles ==
 
 {profiles, [


### PR DESCRIPTION
Otherwise it doesn't work with latest rebar versions and fails with:
```
===> Compiling _build/default/lib/cross_db/src/test/models/person.erl failed
_build/default/lib/cross_db/src/test/models/person.erl:none: undefined parse transform 'xdb_transform'
```