### PR TITLE
Add proper stacktraces to `raise` calls

### DIFF
--- a/src/xdb_lib.erl
+++ b/src/xdb_lib.erl
@@ -150,13 +150,16 @@ reduce_while(Fun, AccIn, List) when is_function(Fun, 2) ->
 
 -spec raise(any()) -> no_return().
 raise(Reason) ->
-  erlang:raise(error, Reason, erlang:get_stacktrace()).
+  {_, Trace} = erlang:process_info(self(), current_stacktrace),
+  erlang:raise(error, Reason, Trace).
 
 -spec raise(atom(), any()) -> no_return().
 raise(Error, Reason) when is_atom(Error) ->
-  erlang:raise(error, {Error, Reason}, erlang:get_stacktrace()).
+  {_, Trace} = erlang:process_info(self(), current_stacktrace),
+  erlang:raise(error, {Error, Reason}, Trace).
 
 -spec raise(atom(), string(), [any()]) -> no_return().
 raise(Error, Text, Args) when is_atom(Error) ->
   Reason = stringify(Text, Args),
-  erlang:raise(error, {Error, Reason}, erlang:get_stacktrace()).
+  {_, Trace} = erlang:process_info(self(), current_stacktrace),
+  erlang:raise(error, {Error, Reason}, Trace).


### PR DESCRIPTION
The issue with `erlang:get_stacktrace` is that it returns last *captured* stacktrace, not the current one. `process_info` call can be used to get current stack trace.