### PR TITLE
Raise exception on invalid query parameters instead of ignoring them

### DIFF
--- a/src/xdb_exception.erl
+++ b/src/xdb_exception.erl
@@ -12,7 +12,8 @@
   multiple_results_error/2,
   no_results_error/1,
   stale_entry_error/2,
-  no_transaction_is_active/0
+  no_transaction_is_active/0,
+  invalid_query_error/2
 ]).
 
 %%%===================================================================
@@ -51,3 +52,8 @@ stale_entry_error(Action, Schema) ->
 -spec no_transaction_is_active() -> no_return().
 no_transaction_is_active() ->
   xdb_lib:raise(no_transaction_is_active, "cannot call rollback outside of transaction").
+
+-spec invalid_query_error(atom(), any()) -> no_return().
+invalid_query_error(Opt, Value) ->
+  Text = "invalid query entry: ~p",
+  xdb_lib:raise(invalid_query_error, Text, [{Opt, Value}]).

--- a/src/xdb_query.erl
+++ b/src/xdb_query.erl
@@ -160,5 +160,5 @@ parse_exprs([{Opt, Value} | Exprs], Acc) ->
     true when is_list(Value); is_tuple(Value) ->
       parse_exprs(Exprs, Acc#{Opt => Value});
     false ->
-      parse_exprs(Exprs, Acc)
+      xdb_exception:invalid_query_error(Opt, Value)
   end.

--- a/test/xdb_query_SUITE.erl
+++ b/test/xdb_query_SUITE.erl
@@ -9,7 +9,8 @@
 -export([
   t_from/1,
   t_validate_operator/1,
-  t_pk_filter/1
+  t_pk_filter/1,
+  t_invalid_query/1
 ]).
 
 -import(xdb_ct, [assert_error/2]).
@@ -75,6 +76,12 @@ t_pk_filter(_Config) ->
   {false, _} = xdb_query:pk_filter(PKs, []),
   ok.
 
+-spec t_invalid_query(xdb_ct:config()) -> ok.
+t_invalid_query(_Config) ->
+  ok = assert_error(fun() ->
+    xdb_query:from(person, [{where, {id, 10}}])
+  end, {invalid_query_error, "invalid query entry: {where,{id,10}}"}).
+
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
@@ -93,6 +100,5 @@ full_query() ->
     {preload,  []},
     {distinct, []},
     {having,   []},
-    {join,     []},
-    {invalid,  []}
+    {join,     []}
   ]).


### PR DESCRIPTION
I propose to raise an exception if we get an unsupported query parameter instead of silently ignoring it, which can lead to hard-to-catch errors for example `repo:get_by(user, {id, 5})` returning multiple results error.