### PR TITLE
Throw error on casting floats to integers (instead of truncating)

### DIFF
--- a/src/schema/xdb_schema_type.erl
+++ b/src/schema/xdb_schema_type.erl
@@ -99,6 +99,6 @@ cast_float(Data) ->
 %% @private
 cast_integer(Data) ->
   case string:to_integer(Data) of
-    {error, no_integer} -> {error, {invalid, Data}};
-    {Integer, _Rest}    -> {ok, Integer}
+    {Integer, []}       -> {ok, Integer};
+    _                   -> {error, {invalid, Data}}
   end.

--- a/test/xdb_schema_type_SUITE.erl
+++ b/test/xdb_schema_type_SUITE.erl
@@ -70,6 +70,7 @@ t_cast_integer(_Config) ->
   {ok, 3} = xdb_schema_type:cast(integer, 3),
   {ok, 3} = xdb_schema_type:cast(integer, 3.14),
 
+  {error, {invalid, _}} = xdb_schema_type:cast(integer, "3.5"),
   {error, {invalid, _}} = xdb_schema_type:cast(integer, "no_integer"),
   {error, {invalid, _}} = xdb_schema_type:cast(integer, '3.14'),
   _ = t_common_invalid_types(integer),


### PR DESCRIPTION
Currently, if value like `5.8` passed into `integer` field it will be silently truncated and saved as `5` which is not explicit and most likely indicates a problem. This commit makes check more strict and raises an error in such cases.