### PR TITLE
Allow returning stacktrace on errors in transaction type spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: erlang
 otp_release:
-  - 20.2
+  - 20.3
 script:
   - rebar3 do dialyzer, ct

--- a/src/repo/xdb_repo_queryable.erl
+++ b/src/repo/xdb_repo_queryable.erl
@@ -145,7 +145,7 @@ transaction(Repo, Adapter, Fun) ->
   Adapter :: xdb_adapter:t(),
   Fun     :: fun(() -> any()),
   Opts    :: xdb_lib:keyword(),
-  Res     :: {ok, any()} | {error, any()}.
+  Res     :: {ok, any()} | {error, any()} | {error, any(), [tuple()]}.
 transaction(Repo, Adapter, Fun, Opts) when is_function(Fun, 0) ->
   Adapter:transaction(Repo, Fun, Opts).
 

--- a/src/test/xdb_repo_basic_test.erl
+++ b/src/test/xdb_repo_basic_test.erl
@@ -211,7 +211,7 @@ t_update(Config) ->
   ok = seed(Config),
   Person = Repo:get(person, 1),
 
-  {ok, CS} =
+  {ok, _CS} =
     xdb_ct:pipe(Person, [
       {fun person:changeset/2, [#{first_name => <<"Joe2">>}]},
       {fun Repo:update/1, []}

--- a/src/xdb_repo.erl
+++ b/src/xdb_repo.erl
@@ -187,4 +187,4 @@
 -callback transaction(Fun, Opts) -> Res when
   Fun  :: fun(() -> any()),
   Opts :: xdb_lib:keyword(),
-  Res  :: {ok, any()} | {error, any()}.
+  Res  :: {ok, any()} | {error, any()} | {error, any(), [tuple()]}.


### PR DESCRIPTION
Hi, the idea here is to allow adapters to return stacktrace on transaction errors as this simplifies debugging a lot. The caller can control it via transaction `Opts` second parameter, something like `[{return_stacktrace, true}]`